### PR TITLE
do not list files that are in google drive's trash

### DIFF
--- a/services/googleDrivePasswordFileManager.js
+++ b/services/googleDrivePasswordFileManager.js
@@ -117,7 +117,8 @@ function GoogleDrivePasswordFileManager($http, $timeout) {
   }
 
   function getPasswordFiles() {
-    var url = "https://www.googleapis.com/drive/v2/files?q=fileExtension='kdbx' or fileExtension='kdb'";
+    var url = "https://www.googleapis.com/drive/v2/files?q=" +
+      "(fileExtension='kdbx' or fileExtension='kdb') and trashed=false";
     return sendAuthorizedGoogleDriveGet(url).then(function(data) {
       return data.items.map(function(entry) {
         return {


### PR DESCRIPTION
This excludes all files from being listed which are in google drive's trash.

When I tried out CKP the first time, I was wondering why the same kdbx file was listed 6 times until I realized that these must come from the trash. I think no one would want to use a file from trash anyways. 

What do you think?